### PR TITLE
Fix Parameter Kind for Drafter >= 3.2.4

### DIFF
--- a/api/parser.go
+++ b/api/parser.go
@@ -316,7 +316,7 @@ func extractHrefs(child *Element) (h Href) {
 			Required:    isContains("attributes.typeAttributes", "required", content),
 			Key:         content.Path("content.key.content").String(),
 			Value:       content.Path("content.value.content").String(),
-			Kind:        content.Path("content.value.element").String(),
+			Kind:        content.Path("meta.title").String(),
 			Description: content.Path("meta.description").String(),
 		}
 


### PR DESCRIPTION
Per this merged PR: https://github.com/apiaryio/drafter/pull/447
The `Kind` is now located at `meta.title` instead of `content.key.content` (which is always `string` now).