### PR TITLE
Update alpha.html to include parameters

### DIFF
--- a/templates/alpha.html
+++ b/templates/alpha.html
@@ -195,8 +195,8 @@
                   <code>{{$transition.URL}}</code>
                 </a>
               </div>
-              {{if $transition.Href.Parameters}}
-                {{template "Parameters" $transition.Href.Parameters}}
+              {{if $resource.Href.Parameters}}
+                {{template "Parameters" $resource.Href.Parameters}}
               {{end}}
               {{if $transaction.Request.Headers}}
                 {{template "Headers" $transaction.Request.Headers}}


### PR DESCRIPTION
The alpha.html template doesn't show parameters.  Updating the template to pull Parameters from $resource fixes this issue.