### PR TITLE
Fixed URL copy - use url from playground instead of current URL address in browser

### DIFF
--- a/templates/winter/panels/PlaygroundPanel.svelte
+++ b/templates/winter/panels/PlaygroundPanel.svelte
@@ -77,7 +77,7 @@
       copying = false;
     }, 2000);
 
-    copyUrl(currentAction, requestParameters);
+    copyUrl(currentUrl, requestParameters);
   }
 </script>
 

--- a/templates/winter/util.js
+++ b/templates/winter/util.js
@@ -296,11 +296,10 @@ const sendRequest = (
   return client.request(options);
 };
 
-const copyUrl = (action, parameters) => {
-  const expandedUrl = expandUrl(action.pathTemplate, populate(parameters));
-  const destUrl = urlParse(expandedUrl, true);
+const copyUrl = (url, parameters) => {
+  const expandedUrl = expandUrl(url.pathname, populate(parameters));
 
-  copy(destUrl.origin + destUrl.pathname);
+  copy(url.origin + expandedUrl);
 };
 
 const getEnv = () => store.get("env");


### PR DESCRIPTION
Hi,
I try to fix problem from issue #73. 
When we have configured playground URL as http://example.com:1234/users and rendered API docs is on http://docs.example.com copied address will be http://docs.example.com/users instead of correct URL http://example.com:1234/users

The problem is there (maybe)
```js
urlParse(expandedUrl, true);
``` 
function `urlParse` returns current browser URL not URL address from playground with endpoint pathname. I think we can use `currentUrl` instead of `currentAction` and omit `urlParse` function.

But maybe I'm wrong?