### PR TITLE
Experimental fetch based http client

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^4.16.4",
     "express-basic-auth": "^1.2.0",
     "handlebars": "^4.1.2",
+    "ky": "^0.15.0",
     "lodash": "^4.17.11",
     "marked": "^0.7.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowboard",
-  "version": "3.5.3",
+  "version": "3.5.4-rc1",
   "description": "API blueprint toolkit",
   "author": "Alif Rachmawadi <subosito@bukalapak.com>",
   "license": "MIT",

--- a/templates/winter.svelte
+++ b/templates/winter.svelte
@@ -19,12 +19,13 @@
     setToken,
     setRefreshToken,
     getToken,
-    exchangeToken,
     isAuth,
     pushHistory,
     basePath,
     getEnv
   } from "./winter/util.js";
+
+  import { exchangeToken } from "./winter/http.js";
 
   import { env, auth, token } from "./winter/store.js";
 

--- a/templates/winter/http.js
+++ b/templates/winter/http.js
@@ -1,0 +1,216 @@
+import axios from "axios";
+import oauth from "axios-oauth-client";
+import qs from "querystringify";
+import urlParse from "url-parse";
+import createAuthRefreshInterceptor from "axios-auth-refresh";
+import ky from "ky";
+import { token } from "./store";
+import {
+  populate,
+  getToken,
+  expandUrl,
+  allowBody,
+  isAuth,
+  getRefreshToken,
+  setToken,
+  setRefreshToken
+} from "./util";
+
+const requestToken = async (client, options) => {
+  const authRequest = oauth.client(client, options);
+  const authCode = await authRequest();
+
+  if (typeof authCode === "string") {
+    const authParsed = qs.parse(authCode);
+    return {
+      accessToken: authParsed.access_token,
+      refreshToken: authParsed.refresh_token
+    };
+  }
+
+  return {
+    accessToken: authCode.access_token,
+    refreshToken: authCode.refresh_token
+  };
+};
+
+const exchangeToken = async (code, options) => {
+  return requestToken(axios.create(), {
+    url: options.tokenUrl,
+    grant_type: "authorization_code",
+    client_id: options.clientId,
+    client_secret: options.clientSecret,
+    redirect_uri: options.callbackUrl,
+    code: code
+  });
+};
+
+const refreshInterceptor = (env, options) => {
+  const refreshToken = getRefreshToken(env);
+
+  return async failedRequest => {
+    const {
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken
+    } = await requestToken(axios, {
+      url: options.tokenUrl,
+      grant_type: "refresh_token",
+      client_id: options.clientId,
+      client_secret: options.clientSecret,
+      refresh_token: refreshToken
+    });
+
+    if (newAccessToken) {
+      token.set(newAccessToken);
+      setToken(env, newAccessToken);
+    }
+
+    if (newRefreshToken) {
+      setRefreshToken(env, newRefreshToken);
+    }
+
+    failedRequest.response.config.headers[
+      "Authorization"
+    ] = `Bearer ${newAccessToken}`;
+  };
+};
+
+const buildRequest = (
+  env,
+  environment,
+  action,
+  { headers, parameters, body }
+) => {
+  const options = {
+    method: action.method,
+    headers: populate(headers)
+  };
+
+  if (environment.auth) {
+    switch (environment.auth.name) {
+      case "basic":
+        options.auth = environment.auth.options;
+        break;
+      case "apikey":
+        options.headers[environment.auth.options.header] =
+          environment.auth.options.key;
+        break;
+      case "oauth2":
+        options.headers["Authorization"] = `Bearer ${getToken(env)}`;
+        break;
+    }
+  }
+
+  const expandedUrl = expandUrl(action.pathTemplate, populate(parameters));
+  const destUrl = urlParse(expandedUrl, true);
+
+  options.params = destUrl.query;
+  options.url = destUrl.pathname;
+
+  if (allowBody(action)) {
+    options.data = body;
+  }
+
+  return options;
+};
+
+const axiosSendRequest = (
+  env,
+  environment,
+  action,
+  { headers, parameters, body }
+) => {
+  const client = axios.create({
+    baseURL: environment.url
+  });
+
+  const options = buildRequest(env, environment, action, {
+    headers,
+    parameters,
+    body
+  });
+
+  if (isAuth(environment, "oauth2")) {
+    createAuthRefreshInterceptor(
+      client,
+      refreshInterceptor(env, environment.auth.options)
+    );
+  }
+
+  return client.request(options);
+};
+
+const kySendRequest = async (
+  env,
+  environment,
+  action,
+  { headers, parameters, body }
+) => {
+  const client = ky.create({
+    prefixUrl: environment.url
+  });
+
+  const options = buildRequest(env, environment, action, {
+    headers,
+    parameters,
+    body
+  });
+
+  if (options.data) {
+    options.body = JSON.stringify(options.data);
+    delete options.data;
+  }
+
+  let url = options.url;
+  delete options.url;
+
+  const query = qs.stringify(options.params);
+  delete options.params;
+
+  if (query != "") {
+    url += `?${query}`;
+  }
+
+  if (environment.http && environment.http.options) {
+    for (let name of Object.keys(environment.http.options)) {
+      options[name] = environment.http.options[name];
+    }
+  }
+
+  const response = await client(url.substr(1), options);
+  const responseHeaders = {};
+
+  for (let headerName of response.headers.keys()) {
+    responseHeaders[headerName] = response.headers.get(headerName);
+  }
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+    data: await response.json()
+  };
+};
+
+const sendRequest = (
+  env,
+  environment,
+  action,
+  { headers, parameters, body }
+) => {
+  if (environment.http && environment.http.client === "fetch") {
+    return kySendRequest(env, environment, action, {
+      headers,
+      parameters,
+      body
+    });
+  }
+
+  return axiosSendRequest(env, environment, action, {
+    headers,
+    parameters,
+    body
+  });
+};
+
+export { exchangeToken, sendRequest };

--- a/templates/winter/panels/PlaygroundPanel.svelte
+++ b/templates/winter/panels/PlaygroundPanel.svelte
@@ -15,9 +15,10 @@
     getToken,
     isAuth,
     allowBody,
-    sendRequest,
     copyUrl
   } from "../util.js";
+
+  import { sendRequest } from "../http.js";
 
   import { env, auth, token } from "../store.js";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,11 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+ky@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.15.0.tgz#bea059d57cc179575adadbba2d8e15610d8fd75b"
+  integrity sha512-6IlJRPFHq4ZKRRa9lyh6YqHqlmddAkfyXI9CYvZpLQtg7fQvwncPHyHrmtXAHKCqHOilINPMT88eW6FTA3HwkA==
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"


### PR DESCRIPTION
You can now customize http client via config:

```yml
html:
  playground:
      mock:
        url: https://mock.example.com/
      mock-fetch:
        url: https://mock.example.com/
        http:
          client: fetch
          options:
            mode: no-cors
            credentials: include
```

> Note: it doesn't support automatic refresh token support for oauth2 yet.