### PR TITLE
JSON.stringify the template path

### DIFF
--- a/lib/internal/bundle.js
+++ b/lib/internal/bundle.js
@@ -79,7 +79,7 @@ async function buildInputOptions(props, options, htmlConfig) {
   const tplSv = tplFile.replace(".html", ".svelte");
 
   const tplJs = `
-import App from '${tplSv}';
+import App from '${JSON.stringify(tplSv)}';
 
 const app = new App({
   target: document.body,

--- a/lib/internal/bundle.js
+++ b/lib/internal/bundle.js
@@ -80,7 +80,7 @@ async function buildInputOptions(props, options, htmlConfig) {
   const tplSv = tplFile.replace(".html", ".svelte");
 
   const tplJs = `
-import App from '${JSON.stringify(tplSv)}';
+import App from ${JSON.stringify(tplSv)};
 
 const app = new App({
   target: document.body,


### PR DESCRIPTION
...to avoid the windows path separate '\' followed by a directory/file that starts with 'u' being parsed as unicode '\u'

For example, if the template file's path is `C:\Users\blah\ui\frontend\node_modules\snowboard\templates\winter.svelte`, then acorn will attempt to parse this as a unicode identifier. `JSON.stringify`ing will escape the escape character `\` which will prevent acorn from attempting to parse it as anything apart from a plain string