### PR TITLE
Feature: Ace editor on playground

### DIFF
--- a/packages/snowboard-theme-winter/package-lock.json
+++ b/packages/snowboard-theme-winter/package-lock.json
@@ -33,6 +33,11 @@
 				"qs": "^6.8.0"
 			}
 		},
+		"brace": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
+			"integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
+		},
 		"clipboard": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
@@ -291,6 +296,14 @@
 			"version": "3.28.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.28.0.tgz",
 			"integrity": "sha512-WJW8wD+aTmU5GUnTUjdhVF35mve2MjylubLgB6fGWoXHpYENdwcwWsWvjMQLayzMynqNH733h1Ck8wJzNR7gdQ=="
+		},
+		"svelte-ace-editor": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/svelte-ace-editor/-/svelte-ace-editor-0.0.2.tgz",
+			"integrity": "sha512-GutGo2bG6v0KqAMoNKhXyg6o9iutrEGAm2NQqfb+7lWzZLY54oN3Bs1yK+CN7kg4zMuZTIdDsdBKw4DqQkPHyw==",
+			"requires": {
+				"brace": "^0.11.1"
+			}
 		},
 		"tiny-emitter": {
 			"version": "2.1.0",

--- a/packages/snowboard-theme-winter/package.json
+++ b/packages/snowboard-theme-winter/package.json
@@ -13,6 +13,7 @@
     "safe-json-stringify": "^1.2.0",
     "snowboard-theme-helper": "^1.1.13",
     "svelte": "^3.28.0",
+    "svelte-ace-editor": "0.0.2",
     "yrv": "0.0.29"
   },
   "files": [

--- a/packages/snowboard-theme-winter/winter/components/panels/PlaygroundPanel.svelte
+++ b/packages/snowboard-theme-winter/winter/components/panels/PlaygroundPanel.svelte
@@ -108,8 +108,6 @@
       return contentTypeHeader.example.includes(contentType)
     })
 
-    console.log(supportedLang, supportedLang ? supportedLang.lang : 'plain_text')
-
     return supportedLang ? supportedLang.lang : 'plain_text'
   }
 


### PR DESCRIPTION
I'm opening this PR to improve the editor in request body of playground.

The editor turns easier typing JSON, XML and others structures. For default, the language to editor is inferred by the request content type, however, it's possible change it for a select other preference.

Example:

![image](https://user-images.githubusercontent.com/20387932/97919773-2240a200-1d37-11eb-8eff-3efcf138fa7d.png)

I hope to contribute and thanks!